### PR TITLE
Fix missing inline keyword for readChunk

### DIFF
--- a/include/bw64/utils.hpp
+++ b/include/bw64/utils.hpp
@@ -35,7 +35,7 @@ namespace bw64 {
     /// @brief Read size bytes from stream into dest
     ///
     /// Dest may be null if size == 0. EOF and stream errors are checked.
-    void readChunk(std::istream& stream, char* dest, size_t size) {
+    inline void readChunk(std::istream& stream, char* dest, size_t size) {
       if (size) {
         stream.read(dest, size);
         if (stream.eof())


### PR DESCRIPTION
Simple fix for compile error (multiply defined functions) due to missing `inline`