### PR TITLE
Fix windows max conflict

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,9 @@ jobs:
 
       - name: Get CMake and ninja
         uses: lukka/get-cmake@v3.20.1
+      
+      - name: Setup msvc dev command prompt on Windows
+        uses: ilammy/msvc-dev-cmd@v1
 
       - name: 'Build with CMake and Ninja'
         uses: lukka/run-cmake@v3

--- a/include/bw64/utils.hpp
+++ b/include/bw64/utils.hpp
@@ -165,9 +165,14 @@ namespace bw64 {
     /// check x against the maximum value that To can hold
     template <typename To, typename From>
     void checkUpper(From x) {
+      // additional parenthesis around numeric_limits are for preventing
+      // conflict with max(a,b) macro on windows without requiring user to
+      // define NOMINMAX
+
       // only need to do this check if From can hold values bigger than To
-      if (std::numeric_limits<From>::max() > std::numeric_limits<To>::max()) {
-        if (x > static_cast<From>(std::numeric_limits<To>::max()))
+      if ((std::numeric_limits<From>::max)() >
+          (std::numeric_limits<To>::max)()) {
+        if (x > static_cast<From>((std::numeric_limits<To>::max)()))
           throw std::runtime_error("overflow");
       }
     }
@@ -182,10 +187,10 @@ namespace bw64 {
       //
       // convert limits to signed, otherwise this comparison can be promoted to
       // unsigned
-      if (static_cast<FromS>(std::numeric_limits<From>::min()) <
-          static_cast<ToS>(std::numeric_limits<To>::min())) {
+      if (static_cast<FromS>((std::numeric_limits<From>::min)()) <
+          static_cast<ToS>((std::numeric_limits<To>::min)())) {
         // from is signed, to maybe unsigned
-        if (x < static_cast<FromS>(std::numeric_limits<To>::min()))
+        if (x < static_cast<FromS>((std::numeric_limits<To>::min)()))
           throw std::runtime_error("underflow");
       }
     }
@@ -203,8 +208,8 @@ namespace bw64 {
     /// representable by T; use safeCast to make sure
     template <typename T>
     T safeAdd(T x, T y) {
-      if (((y > 0) && (x > (std::numeric_limits<T>::max() - y))) ||
-          ((y < 0) && (x < (std::numeric_limits<T>::min() - y))))
+      if (((y > 0) && (x > ((std::numeric_limits<T>::max)() - y))) ||
+          ((y < 0) && (x < ((std::numeric_limits<T>::min)() - y))))
         throw std::runtime_error(y > 0 ? "overflow" : "underflow");
       return x + y;
     }

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -199,9 +199,9 @@ TEST_CASE("write_chunk_without_padding") {
 
 template <typename T>
 void checkSameType() {
-  CHECK_NOTHROW(utils::safeCast<T>(std::numeric_limits<T>::max()));
+  CHECK_NOTHROW(utils::safeCast<T>((std::numeric_limits<T>::max)()));
   CHECK_NOTHROW(utils::safeCast<T>(static_cast<T>(0)));
-  CHECK_NOTHROW(utils::safeCast<T>(std::numeric_limits<T>::min()));
+  CHECK_NOTHROW(utils::safeCast<T>((std::numeric_limits<T>::min)()));
 }
 
 // when positive range of U is greater than T
@@ -209,15 +209,15 @@ template <typename T, typename U>
 void checkLargerTypePositive() {
   CHECK_NOTHROW(utils::safeCast<T>(static_cast<U>(0)));
   CHECK_NOTHROW(
-      utils::safeCast<T>(static_cast<U>(std::numeric_limits<T>::max())));
+      utils::safeCast<T>(static_cast<U>((std::numeric_limits<T>::max)())));
   CHECK_THROWS_WITH(
-      utils::safeCast<T>(static_cast<U>(std::numeric_limits<T>::max()) + 1),
+      utils::safeCast<T>(static_cast<U>((std::numeric_limits<T>::max)()) + 1),
       "overflow");
-  CHECK_THROWS_WITH(utils::safeCast<T>(std::numeric_limits<U>::max()),
+  CHECK_THROWS_WITH(utils::safeCast<T>((std::numeric_limits<U>::max)()),
                     "overflow");
 
   CHECK_NOTHROW(utils::safeCast<U>(static_cast<T>(0)));
-  CHECK_NOTHROW(utils::safeCast<U>(std::numeric_limits<T>::max()));
+  CHECK_NOTHROW(utils::safeCast<U>((std::numeric_limits<T>::max)()));
 }
 
 // when negative range of U is greater than T
@@ -225,15 +225,15 @@ template <typename T, typename U>
 void checkLargerTypeNegative() {
   CHECK_NOTHROW(utils::safeCast<T>(static_cast<U>(0)));
   CHECK_NOTHROW(
-      utils::safeCast<T>(static_cast<U>(std::numeric_limits<T>::min())));
+      utils::safeCast<T>(static_cast<U>((std::numeric_limits<T>::min)())));
   CHECK_THROWS_WITH(
-      utils::safeCast<T>(static_cast<U>(std::numeric_limits<T>::min()) - 1),
+      utils::safeCast<T>(static_cast<U>((std::numeric_limits<T>::min)()) - 1),
       "underflow");
-  CHECK_THROWS_WITH(utils::safeCast<T>(std::numeric_limits<U>::min()),
+  CHECK_THROWS_WITH(utils::safeCast<T>((std::numeric_limits<U>::min)()),
                     "underflow");
 
   CHECK_NOTHROW(utils::safeCast<U>(static_cast<T>(0)));
-  CHECK_NOTHROW(utils::safeCast<U>(std::numeric_limits<T>::min()));
+  CHECK_NOTHROW(utils::safeCast<U>((std::numeric_limits<T>::min)()));
 }
 
 TEST_CASE("safe cast") {
@@ -258,40 +258,40 @@ TEST_CASE("safe cast") {
 template <typename T>
 void checkAddPositive() {
   CHECK_NOTHROW(utils::safeAdd<T>(0, 0));
-  CHECK_NOTHROW(utils::safeAdd<T>(0, std::numeric_limits<T>::max()));
-  CHECK_NOTHROW(utils::safeAdd<T>(std::numeric_limits<T>::max(), 0));
+  CHECK_NOTHROW(utils::safeAdd<T>(0, (std::numeric_limits<T>::max)()));
+  CHECK_NOTHROW(utils::safeAdd<T>((std::numeric_limits<T>::max)(), 0));
 
-  CHECK_NOTHROW(utils::safeAdd<T>(1, std::numeric_limits<T>::max() - 1));
-  CHECK_NOTHROW(utils::safeAdd<T>(std::numeric_limits<T>::max() - 1, 1));
+  CHECK_NOTHROW(utils::safeAdd<T>(1, (std::numeric_limits<T>::max)() - 1));
+  CHECK_NOTHROW(utils::safeAdd<T>((std::numeric_limits<T>::max)() - 1, 1));
 
-  CHECK_THROWS_WITH(utils::safeAdd<T>(1, std::numeric_limits<T>::max()),
+  CHECK_THROWS_WITH(utils::safeAdd<T>(1, (std::numeric_limits<T>::max)()),
                     "overflow");
-  CHECK_THROWS_WITH(utils::safeAdd<T>(std::numeric_limits<T>::max(), 1),
+  CHECK_THROWS_WITH(utils::safeAdd<T>((std::numeric_limits<T>::max)(), 1),
                     "overflow");
 
-  CHECK_THROWS_WITH(utils::safeAdd<T>(std::numeric_limits<T>::max(),
-                                      std::numeric_limits<T>::max()),
+  CHECK_THROWS_WITH(utils::safeAdd<T>((std::numeric_limits<T>::max)(),
+                                      (std::numeric_limits<T>::max)()),
                     "overflow");
 }
 
 template <typename T>
 void checkAddNegative() {
   CHECK_NOTHROW(utils::safeAdd<T>(0, 0));
-  CHECK_NOTHROW(utils::safeAdd<T>(0, std::numeric_limits<T>::min()));
-  CHECK_NOTHROW(utils::safeAdd<T>(std::numeric_limits<T>::min(), 0));
-  CHECK_NOTHROW(utils::safeAdd<T>(1, std::numeric_limits<T>::min()));
-  CHECK_NOTHROW(utils::safeAdd<T>(std::numeric_limits<T>::min(), 1));
+  CHECK_NOTHROW(utils::safeAdd<T>(0, (std::numeric_limits<T>::min)()));
+  CHECK_NOTHROW(utils::safeAdd<T>((std::numeric_limits<T>::min)(), 0));
+  CHECK_NOTHROW(utils::safeAdd<T>(1, (std::numeric_limits<T>::min)()));
+  CHECK_NOTHROW(utils::safeAdd<T>((std::numeric_limits<T>::min)(), 1));
 
-  CHECK_NOTHROW(utils::safeAdd<T>(-1, std::numeric_limits<T>::max()));
-  CHECK_NOTHROW(utils::safeAdd<T>(std::numeric_limits<T>::max(), -1));
+  CHECK_NOTHROW(utils::safeAdd<T>(-1, (std::numeric_limits<T>::max)()));
+  CHECK_NOTHROW(utils::safeAdd<T>((std::numeric_limits<T>::max)(), -1));
 
-  CHECK_THROWS_WITH(utils::safeAdd<T>(-1, std::numeric_limits<T>::min()),
+  CHECK_THROWS_WITH(utils::safeAdd<T>(-1, (std::numeric_limits<T>::min)()),
                     "underflow");
-  CHECK_THROWS_WITH(utils::safeAdd<T>(std::numeric_limits<T>::min(), -1),
+  CHECK_THROWS_WITH(utils::safeAdd<T>((std::numeric_limits<T>::min)(), -1),
                     "underflow");
 
-  CHECK_THROWS_WITH(utils::safeAdd<T>(std::numeric_limits<T>::min(),
-                                      std::numeric_limits<T>::min()),
+  CHECK_THROWS_WITH(utils::safeAdd<T>((std::numeric_limits<T>::min)(),
+                                      (std::numeric_limits<T>::min)()),
                     "underflow");
 }
 

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -1,3 +1,6 @@
+#ifdef _WIN32
+#include "windows.h"  // This is to trigger max / std::numeric_limits::max conflict
+#endif
 #include <catch2/catch.hpp>
 #include "bw64/bw64.hpp"
 


### PR DESCRIPTION
On windows, a macro `max(a, b)` is present in `minwindef.h`. This is included via `windows.h`
This macro conflicts with `std::numeric_limits<T>::max` which can cause build errors.
Surrounding `std::numeric_limits<T>::max` with parenthesis disambiguates things.

The PR does 3 things:
* Updates build.yml to use msvc for windows builds (was previously using gcc)
* Includes "windows.h" in utils_tests.cpp when building on windows to expose issue
* Fixes issue by adding additional parenthesis in utils.hpp

