### PR TITLE
Improve pcm encoding and decoding

### DIFF
--- a/include/bw64/utils.hpp
+++ b/include/bw64/utils.hpp
@@ -91,7 +91,7 @@ namespace bw64 {
     /// scale factor for converting between floats and ints
     template <typename T, int bits>
     constexpr T scaleFactor() {
-      return static_cast<T>((static_cast<uint32_t>(1) << (bits - 1)) - 1);
+      return static_cast<T>(static_cast<uint32_t>(1) << (bits - 1));
     }
 
     /// encode one sample to PCM
@@ -106,7 +106,7 @@ namespace bw64 {
 
       constexpr IntT maxval =
           static_cast<IntT>((UnsignedT{1} << (bits - 1)) - 1);
-      constexpr IntT minval = -maxval;
+      constexpr IntT minval = -maxval - 1;
 
       // clip or convert to int
       IntT value_int;

--- a/include/bw64/utils.hpp
+++ b/include/bw64/utils.hpp
@@ -75,6 +75,19 @@ namespace bw64 {
       }
     }
 
+    /// @brief Limit sample to [-1,+1]
+    template <typename T,
+              typename = std::enable_if<std::is_floating_point<T>::value>>
+    T clipSample(T value) {
+      if (value > 1.f) {
+        return 1.f;
+      }
+      if (value < -1.f) {
+        return -1.f;
+      }
+      return value;
+    }
+
     /// scale factor for converting between floats and ints
     template <typename T, int bits>
     constexpr T scaleFactor() {
@@ -131,7 +144,7 @@ namespace bw64 {
 
       constexpr T scale_inv = T{1} / scaleFactor<T, bits>();
 
-      return scale_inv * value;
+      return clipSample(scale_inv * value);
     }
 
     /// @brief Decode (integer) PCM samples as float from char array
@@ -156,19 +169,6 @@ namespace bw64 {
         errorString << "unsupported number of bits: " << bitsPerSample;
         throw std::runtime_error(errorString.str());
       }
-    }
-
-    /// @brief Limit sample to [-1,+1]
-    template <typename T,
-              typename = std::enable_if<std::is_floating_point<T>::value>>
-    T clipSample(T value) {
-      if (value > 1.f) {
-        return 1.f;
-      }
-      if (value < -1.f) {
-        return -1.f;
-      }
-      return value;
     }
 
     /// @brief Encode PCM samples from float array to char array

--- a/include/bw64/utils.hpp
+++ b/include/bw64/utils.hpp
@@ -4,6 +4,7 @@
  * Collection of helper functions.
  */
 #pragma once
+#include <cmath>
 #include <sstream>
 #include <stdexcept>
 #include <limits>
@@ -101,7 +102,7 @@ namespace bw64 {
       else if (value <= static_cast<T>(minval))
         value_int = minval;
       else
-        value_int = static_cast<IntT>(value);
+        value_int = static_cast<IntT>(std::lrint(value));
 
       for (size_t i = 0; i < bytes; i++)
         buffer[i] = (value_int >> (8 * i)) & 0xff;

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -89,7 +89,7 @@ TEST_CASE("encode_pcm_samples_16bit") {
   const char* encodedSamples =
       "\x00\x00"
       "\xff\x7f"
-      "\x01\x80"
+      "\x00\x80"
       "\x00\x40"
       "\x00\xc0";
   char encoded16bit[10];
@@ -106,7 +106,7 @@ TEST_CASE("encode_pcm_samples_24bit") {
   const char* encodedSamples =
       "\x00\x00\x00"
       "\xff\xff\x7f"
-      "\x01\x00\x80"
+      "\x00\x00\x80"
       "\x00\x00\x40"
       "\x00\x00\xc0";
   char encoded24bit[15];
@@ -123,7 +123,7 @@ TEST_CASE("encode_pcm_samples_32bit") {
   const char* encodedSamples =
       "\x00\x00\x00\x00"
       "\xff\xff\xff\x7f"
-      "\x01\x00\x00\x80"
+      "\x00\x00\x00\x80"
       "\x00\x00\x00\x40"
       "\x00\x00\x00\xc0";
   char encoded32bit[20];
@@ -188,9 +188,6 @@ void checkDecodeEncodeOne(uint64_t value) {
   utils::decodePcmSamples(sample, &decoded, 1, bits);
   char encoded[bytes];
   utils::encodePcmSamples(&decoded, encoded, 1, bits);
-
-  // current scale doesn't pass through a value of -1
-  if (value == ((uint64_t)1 << (bits - 1))) return;
 
   uint64_t encoded_value = 0;
   for (size_t c = 0; c < bytes; c++)

--- a/tests/utils_tests.cpp
+++ b/tests/utils_tests.cpp
@@ -90,8 +90,8 @@ TEST_CASE("encode_pcm_samples_16bit") {
       "\x00\x00"
       "\xff\x7f"
       "\x01\x80"
-      "\xff\x3f"
-      "\x01\xc0";
+      "\x00\x40"
+      "\x00\xc0";
   char encoded16bit[10];
 
   const float samples[] = {0.f, 1.f, -1.f, 0.5f, -0.5f};
@@ -107,8 +107,8 @@ TEST_CASE("encode_pcm_samples_24bit") {
       "\x00\x00\x00"
       "\xff\xff\x7f"
       "\x01\x00\x80"
-      "\xff\xff\x3f"
-      "\x01\x00\xc0";
+      "\x00\x00\x40"
+      "\x00\x00\xc0";
   char encoded24bit[15];
 
   const float samples[] = {0.f, 1.f, -1.f, 0.5f, -0.5f};
@@ -124,8 +124,8 @@ TEST_CASE("encode_pcm_samples_32bit") {
       "\x00\x00\x00\x00"
       "\xff\xff\xff\x7f"
       "\x01\x00\x00\x80"
-      "\xff\xff\xff\x3f"
-      "\x01\x00\x00\xc0";
+      "\x00\x00\x00\x40"
+      "\x00\x00\x00\xc0";
   char encoded32bit[20];
 
   const float samples[] = {0.f, 1.f, -1.f, 0.5f, -0.5f};


### PR DESCRIPTION
Some changes to PCM encoding and decoding, mainly to make sure that reading then writing a file results in the same samples.

This consists of a refactor to easily support the changes but without any changes in behavior, followed by small changes. see the commit messages for details and reasoning.

This was partially motivated by #25 too, but I was wrong about that. These changes technically rely on undefined behaviour (assuming that integers are represented in two's complement), however in practice it's always been OK to rely on this, and it's defined in C++20, see https://en.cppreference.com/w/cpp/language/types#Range_of_values