### PR TITLE
Support use of RF64 chunk ID

### DIFF
--- a/include/bw64/writer.hpp
+++ b/include/bw64/writer.hpp
@@ -25,7 +25,7 @@ namespace bw64 {
    *
    * This is a
    * [RAII](https://en.wikipedia.org/wiki/Resource_acquisition_is_initialization)
-   * class, meaning that the file will be openend and initialized (required
+   * class, meaning that the file will be opened and initialized (required
    * headers etc.) on construction, and closed and finalized (writing chunk
    * sizes etc.) on destruction.
    */
@@ -156,6 +156,9 @@ namespace bw64 {
       return false;
     }
 
+    /// @brief Use RF64 ID for outer chunk (when >4GB) rather than BW64
+    void useRf64Id(bool state) { useRf64Id_ = state; }
+
     void setChnaChunk(std::shared_ptr<ChnaChunk> chunk) {
       if (chunk->numUids() > 1024) {
         // TODO: make pre data chunk chna chunk a JUNK chunk and add chnaChunk
@@ -204,7 +207,8 @@ namespace bw64 {
       auto last_position = fileStream_.tellp();
       fileStream_.seekp(0);
       if (isBw64File()) {
-        utils::writeValue(fileStream_, utils::fourCC("BW64"));
+        utils::writeValue(fileStream_,
+                          utils::fourCC(useRf64Id_ ? "RF64" : "BW64"));
         utils::writeValue(fileStream_, (std::numeric_limits<uint32_t>::max)());
         overwriteJunkWithDs64Chunk();
       } else {
@@ -308,6 +312,7 @@ namespace bw64 {
     std::vector<std::shared_ptr<Chunk>> chunks_;
     std::vector<ChunkHeader> chunkHeaders_;
     std::vector<std::shared_ptr<Chunk>> postDataChunks_;
+    bool useRf64Id_{false};
   };
 
 }  // namespace bw64


### PR DESCRIPTION
When set, uses RF64 ID for outer chunk rather then BW64 when the file is >4GB