### PR TITLE
Fix fmt extra data handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,13 @@ This version fixes a number of buffer overruns, integer overflows, and uses of u
 - Renamed CMake library target name from `libbw64` to `bw64`
 - Renamed CMake option `UNIT_TESTS` to `BW64_UNIT_TESTS`
 - Renamed CMake option `EXAMPLES` to `BW64_EXAMPLES`
+- `FormatInfoChunk::formatTag` now matches the formatTag in the file, rather than always returning 1
+- fmt parsing is stricter -- the chunk size must match the use of cbSize, and the presence if extra data is checked against the formatTag
 
 ### Fixed
 
 - Fix sample rate parameter type in `writeFile()` and `BW64Writer` ctor to support 96k samplerates
+- fmt extra data is now written correctly
 
 ## 0.10.0 - (January 18, 2019)
 ### Added

--- a/include/bw64/chunks.hpp
+++ b/include/bw64/chunks.hpp
@@ -189,7 +189,7 @@ namespace bw64 {
         utils::writeValue(stream, extraData()->validBitsPerSample());
         utils::writeValue(stream, extraData()->dwChannelMask());
         utils::writeValue(stream, extraData()->subFormat());
-        utils::writeValue(stream, extraData()->subFormatString());
+        stream << extraData()->subFormatString();
       }
     }
 

--- a/include/bw64/chunks.hpp
+++ b/include/bw64/chunks.hpp
@@ -185,6 +185,7 @@ namespace bw64 {
       utils::writeValue(stream, blockAlignment());
       utils::writeValue(stream, bitsPerSample());
       if (extraData()) {
+        utils::writeValue(stream, uint16_t{22});  // cbSize
         utils::writeValue(stream, extraData()->validBitsPerSample());
         utils::writeValue(stream, extraData()->dwChannelMask());
         utils::writeValue(stream, extraData()->subFormat());

--- a/include/bw64/chunks.hpp
+++ b/include/bw64/chunks.hpp
@@ -117,10 +117,12 @@ namespace bw64 {
      * @param sampleRate sample rate of the audio data
      * @param bitDepth bit depth used in file
      * @param extraData custom ExtraData (optional, nullptr if not custom)
+     * @param formatTag format tag, defaults to PCM
      */
     FormatInfoChunk(uint16_t channels, uint32_t sampleRate, uint32_t bitDepth,
-                    std::shared_ptr<ExtraData> extraData = nullptr) {
-      formatTag_ = 1;
+                    std::shared_ptr<ExtraData> extraData = nullptr,
+                    uint16_t formatTag = 1) {
+      formatTag_ = formatTag;
       channelCount_ = channels;
       sampleRate_ = sampleRate;
       bitsPerSample_ = bitDepth;

--- a/include/bw64/parser.hpp
+++ b/include/bw64/parser.hpp
@@ -92,7 +92,7 @@ namespace bw64 {
     }
 
     auto formatInfoChunk = std::make_shared<FormatInfoChunk>(
-        channelCount, sampleRate, bitsPerSample, extraData);
+        channelCount, sampleRate, bitsPerSample, extraData, formatTag);
 
     if (formatInfoChunk->blockAlignment() != blockAlignment) {
       std::stringstream errorString;

--- a/include/bw64/reader.hpp
+++ b/include/bw64/reader.hpp
@@ -249,8 +249,8 @@ namespace bw64 {
      *
      * @returns number of frames read
      */
-    template <typename T,
-              typename = std::enable_if<std::is_floating_point<T>::value>>
+    template <typename T, typename std::enable_if<
+                              std::is_floating_point<T>::value, int>::type = 0>
     uint64_t read(T* outBuffer, uint64_t frames) {
       if (tell() + frames > numberOfFrames()) {
         frames = numberOfFrames() - tell();

--- a/include/bw64/utils.hpp
+++ b/include/bw64/utils.hpp
@@ -77,8 +77,8 @@ namespace bw64 {
     }
 
     /// @brief Limit sample to [-1,+1]
-    template <typename T,
-              typename = std::enable_if<std::is_floating_point<T>::value>>
+    template <typename T, typename std::enable_if<
+                              std::is_floating_point<T>::value, int>::type = 0>
     T clipSample(T value) {
       if (value > 1.f) {
         return 1.f;
@@ -97,7 +97,8 @@ namespace bw64 {
 
     /// encode one sample to PCM
     template <int bytes, typename IntT, typename T,
-              typename = std::enable_if<std::is_floating_point<T>::value>>
+              typename std::enable_if<std::is_floating_point<T>::value,
+                                      int>::type = 0>
     void encode(T value, char* buffer) {
       static_assert(sizeof(IntT) >= bytes, "IntT must be larger than bytes");
       constexpr int bits = bytes * 8;
@@ -124,7 +125,8 @@ namespace bw64 {
 
     /// decode one sample from PCM
     template <int bytes, typename IntT, typename T,
-              typename = std::enable_if<std::is_floating_point<T>::value>>
+              typename std::enable_if<std::is_floating_point<T>::value,
+                                      int>::type = 0>
     T decode(const char* buffer) {
       static_assert(sizeof(IntT) >= bytes, "IntT must be larger than bytes");
       constexpr int bits = bytes * 8;
@@ -149,8 +151,8 @@ namespace bw64 {
     }
 
     /// @brief Decode (integer) PCM samples as float from char array
-    template <typename T,
-              typename = std::enable_if<std::is_floating_point<T>::value>>
+    template <typename T, typename std::enable_if<
+                              std::is_floating_point<T>::value, int>::type = 0>
     void decodePcmSamples(const char* inBuffer, T* outBuffer,
                           uint64_t numberOfSamples, uint16_t bitsPerSample) {
       if (bitsPerSample == 16) {

--- a/include/bw64/utils.hpp
+++ b/include/bw64/utils.hpp
@@ -49,7 +49,10 @@ namespace bw64 {
     }
 
     /// @brief Write a value to a stream
-    template <typename T>
+    template <typename T,
+              typename std::enable_if<
+                  std::is_integral<typename std::remove_extent<T>::type>::value,
+                  int>::type = 0>
     void writeValue(std::ostream& stream, const T& src) {
       stream.write(reinterpret_cast<const char*>(&src), sizeof(src));
     }

--- a/include/bw64/writer.hpp
+++ b/include/bw64/writer.hpp
@@ -292,8 +292,8 @@ namespace bw64 {
      *
      * @returns number of frames written
      */
-    template <typename T,
-              typename = std::enable_if<std::is_floating_point<T>::value>>
+    template <typename T, typename std::enable_if<
+                              std::is_floating_point<T>::value, int>::type = 0>
     uint64_t write(T* inBuffer, uint64_t frames) {
       uint64_t bytesWritten = frames * formatChunk()->blockAlignment();
       rawDataBuffer_.resize(bytesWritten);

--- a/tests/chunk_tests.cpp
+++ b/tests/chunk_tests.cpp
@@ -176,6 +176,21 @@ TEST_CASE("format_info_chunk_extradata") {
         std::string("\x00\x00\x00\x00\x00\x10\x80\x00\x00\xaa\x00\x38\x9b\x71",
                     14));
   }
+  SECTION("PCM with extradata") {
+    const char* formatChunkByteArray =
+        "\x01\x00\x01\x00"  // formatTag = 1; channelCount = 1
+        "\x80\xbb\x00\x00"  // sampleRate = 48000
+        "\x00\x77\x01\x00"  // bytesPerSecond = 96000
+        "\x02\x00\x10\x00"  // blockAlignment = 2; bitsPerSample = 16
+        "\x16\x00"  // cbSize = 22
+        "\x10\x00"  // validBitsPerSample = 16
+        "\x04\x00\x00\x00"  // dwChannelMask = SPEAKER_FRONT_CENTER
+        "\x01\x00\x00\x00\x00\x00\x00\x10\x80\x00\x00\xaa\x00\x38\x9b\x71";  // KSDATAFORMAT_SUBTYPE_PCM
+    std::istringstream formatChunkStream(std::string(formatChunkByteArray, 40));
+    REQUIRE_THROWS_AS(
+        parseFormatInfoChunk(formatChunkStream, utils::fourCC("fmt "), 40),
+        std::runtime_error);
+  }
 }
 
 TEST_CASE("chna_chunk") {

--- a/tests/chunk_tests.cpp
+++ b/tests/chunk_tests.cpp
@@ -175,6 +175,12 @@ TEST_CASE("format_info_chunk_extradata") {
         extraData->subFormatString() ==
         std::string("\x00\x00\x00\x00\x00\x10\x80\x00\x00\xaa\x00\x38\x9b\x71",
                     14));
+
+    SECTION("write") {
+      std::ostringstream written;
+      formatInfoChunk->write(written);
+      REQUIRE(formatChunkStream.str() == written.str());
+    }
   }
   SECTION("PCM with extradata") {
     const char* formatChunkByteArray =

--- a/tests/file_tests.cpp
+++ b/tests/file_tests.cpp
@@ -29,7 +29,7 @@ TEST_CASE("read_rect_24bit") {
 
 TEST_CASE("read_rect_32bit") {
   auto bw64File = readFile("rect_32bit.wav");
-  REQUIRE(bw64File->formatTag() == 1u);
+  REQUIRE(bw64File->formatTag() == 0xfffeu);
   REQUIRE(bw64File->bitDepth() == 32u);
   REQUIRE(bw64File->sampleRate() == 44100u);
   REQUIRE(bw64File->channels() == 2u);


### PR DESCRIPTION
passing `formatTag` to `FormatInfoChunk` as the last parameter feels messy. I considered:

- passing it as the first parameter, but this would either change the API, or possibly be ambiguous as there's already an optional parameter
- detecting it from extraData presence, but I want to support floating point, which has a different type but no extraData