### PR TITLE
fix writing large axml chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This version fixes a number of buffer overruns, integer overflows, and uses of u
 - Renamed CMake option `EXAMPLES` to `BW64_EXAMPLES`
 - `FormatInfoChunk::formatTag` now matches the formatTag in the file, rather than always returning 1
 - fmt parsing is stricter -- the chunk size must match the use of cbSize, and the presence if extra data is checked against the formatTag
+- strings can be moved into `AxmlChunk` with `std::make_shared<AxmlChunk>(std:move(some_str))`, to avoid a copy when writing
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This version fixes a number of buffer overruns, integer overflows, and uses of u
 
 - Fix sample rate parameter type in `writeFile()` and `BW64Writer` ctor to support 96k samplerates
 - fmt extra data is now written correctly
+- axml chunks greater than 4GB are now written correctly
 
 ## 0.10.0 - (January 18, 2019)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This version fixes a number of buffer overruns, integer overflows, and uses of u
 - library can now easier be used as a CMake subproject
 - new CMake option `BW64_PACKAGE_AND_INSTALL`
 - `AxmlChunk::data()`; this allows access to the internal string, avoiding a copy when reading
+- `Bw64Writer::close()`; this should be called before destruction to properly catch exceptions
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This version fixes a number of buffer overruns, integer overflows, and uses of u
 
 - library can now easier be used as a CMake subproject
 - new CMake option `BW64_PACKAGE_AND_INSTALL`
+- `AxmlChunk::data()`; this allows access to the internal string, avoiding a copy when reading
 
 ### Changed
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -53,6 +53,8 @@ table.
 
 Note that we don't need to close our file at the end of the programme. This will
 be done automatically when ``inFile`` is destroyed at the end of the programme.
+In real applications :cpp:func:`bw64::Bw64Reader::close()` should be calles
+before destruction to be able to properly catch exceptions.
 
 Write files
 -----------
@@ -92,6 +94,10 @@ passed to the :cpp:func:`bw64::Bw64Reader::read()` in the
 :cpp:func:`bw64::Bw64Writer::write()` function to write the unmodified samples.
 So also the :cpp:func:`bw64::Bw64Writer::write()` expects the order of the
 samples to be interleaved as described above.
+
+As with reading, the file will be automatically closed during destruction, but
+in real applications :cpp:func:`bw64::Bw64Writer::close()` should be called
+before destruction to be able to properly catch exceptions.
 
 Add signal processing
 ---------------------

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1700403855,
+        "narHash": "sha256-Q0Uzjik9kUTN9pd/kp52XJi5kletBhy29ctBlAG+III=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0c5678df521e1407884205fe3ce3cf1d7df297db",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-23.05",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,38 @@
+{
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.nixpkgs.url = "nixpkgs/nixos-23.05";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+
+          libbw64_pkg = { stdenv, cmake, ninja }:
+            stdenv.mkDerivation {
+              name = "libbw64";
+              src = ./.;
+              nativeBuildInputs = [ cmake ninja ];
+              doCheck = true;
+            };
+        in
+        rec {
+          packages = rec {
+            libbw64 = pkgs.callPackage libbw64_pkg { };
+
+            default = libbw64;
+          };
+
+          devShells = rec {
+            libbw64 = packages.libbw64.overrideAttrs (attrs: {
+              nativeBuildInputs = attrs.nativeBuildInputs ++ [
+                pkgs.clang-tools
+                pkgs.nixpkgs-fmt
+              ];
+            });
+
+            default = libbw64;
+          };
+        });
+}
+

--- a/include/bw64/chunks.hpp
+++ b/include/bw64/chunks.hpp
@@ -266,6 +266,8 @@ namespace bw64 {
      */
     void write(std::ostream& stream) const override { stream << data_; }
 
+    const std::string& data() const { return data_; }
+
    private:
     std::string data_;
   };

--- a/include/bw64/chunks.hpp
+++ b/include/bw64/chunks.hpp
@@ -256,9 +256,7 @@ namespace bw64 {
    public:
     static uint32_t Id() { return utils::fourCC("axml"); }
 
-    AxmlChunk(const std::string& axml) {
-      std::copy(axml.begin(), axml.end(), std::back_inserter(data_));
-    }
+    AxmlChunk(std::string axml) : data_(std::move(axml)) {}
 
     uint32_t id() const override { return AxmlChunk::Id(); }
     uint64_t size() const override { return data_.size(); }
@@ -266,13 +264,10 @@ namespace bw64 {
     /*
      * @brief Write the AxmlChunk to a stream
      */
-    void write(std::ostream& stream) const override {
-      std::copy(data_.begin(), data_.end(),
-                std::ostreambuf_iterator<char>(stream));
-    }
+    void write(std::ostream& stream) const override { stream << data_; }
 
    private:
-    std::vector<char> data_;
+    std::string data_;
   };
 
   /**

--- a/include/bw64/parser.hpp
+++ b/include/bw64/parser.hpp
@@ -120,8 +120,7 @@ namespace bw64 {
       errorString << "chunkId != 'axml'";
       throw std::runtime_error(errorString.str());
     }
-    std::string data;
-    data.resize(size);
+    std::string data(size, 0);
     // since c++11, std::string[0] returns a valid reference to a null byte for
     // size==0
     utils::readChunk(stream, &data[0], size);

--- a/include/bw64/parser.hpp
+++ b/include/bw64/parser.hpp
@@ -125,7 +125,7 @@ namespace bw64 {
     // since c++11, std::string[0] returns a valid reference to a null byte for
     // size==0
     utils::readChunk(stream, &data[0], size);
-    return std::make_shared<AxmlChunk>(data);
+    return std::make_shared<AxmlChunk>(std::move(data));
   }
 
   ///@brief Parse AudioId from input stream

--- a/include/bw64/reader.hpp
+++ b/include/bw64/reader.hpp
@@ -81,13 +81,22 @@ namespace bw64 {
       seek(0);
     }
 
-    /**
-     * @brief Bw64Reader destructor
-     *
-     * The destructor will automatically close the file opened in the
-     * constructor.
-     */
-    ~Bw64Reader() { fileStream_.close(); }
+    /// close the file
+    ///
+    /// It is recommended to call this before the destructor, to handle
+    /// exceptions.
+    void close() {
+      if (!fileStream_.is_open()) return;
+
+      fileStream_.close();
+
+      if (!fileStream_.good())
+        throw std::runtime_error("file error detected when closing");
+    }
+
+    /// destructor; this will close the file if it has not already been done,
+    /// but it is recommended to call close() first to handle exceptions
+    ~Bw64Reader() { close(); }
 
     /// @brief Get file format (RIFF, BW64 or RF64)
     uint32_t fileFormat() const { return fileFormat_; }

--- a/include/bw64/writer.hpp
+++ b/include/bw64/writer.hpp
@@ -57,7 +57,8 @@ namespace bw64 {
         throw std::runtime_error(errorString.str());
       }
       writeRiffHeader();
-      writeChunkPlaceholder(utils::fourCC("JUNK"), 28u);
+      // 28 byte ds64 header + 12 byte entry for axml
+      writeChunkPlaceholder(utils::fourCC("JUNK"), 40u);
       auto formatChunk =
           std::make_shared<FormatInfoChunk>(channels, sampleRate, bitDepth);
       writeChunk(formatChunk);

--- a/include/bw64/writer.hpp
+++ b/include/bw64/writer.hpp
@@ -151,9 +151,10 @@ namespace bw64 {
       if (riffChunkSize() > UINT32_MAX) {
         return true;
       }
-      if (dataChunk()->size() > UINT32_MAX) {
-        return true;
-      }
+
+      for (auto& header : chunkHeaders_)
+        if (header.size > UINT32_MAX) return true;
+
       return false;
     }
 
@@ -223,8 +224,13 @@ namespace bw64 {
     void overwriteJunkWithDs64Chunk() {
       auto ds64Chunk = std::make_shared<DataSize64Chunk>();
       ds64Chunk->bw64Size(riffChunkSize());
+      // write data size even if it's not too big
       ds64Chunk->dataSize(dataChunk()->size());
-      // TODO: add other chunks which are bigger than 4GB
+
+      for (auto& header : chunkHeaders_)
+        if (header.size > UINT32_MAX)
+          ds64Chunk->setChunkSize(header.id, header.size);
+
       overwriteChunk(utils::fourCC("JUNK"), ds64Chunk);
     }
 

--- a/include/bw64/writer.hpp
+++ b/include/bw64/writer.hpp
@@ -267,6 +267,15 @@ namespace bw64 {
     /// @brief Overwrite chunk template
     template <typename ChunkType>
     void overwriteChunk(uint32_t id, std::shared_ptr<ChunkType> chunk) {
+      if (chunk->size() > chunkHeader(id).size) {
+        std::stringstream errorMsg;
+        errorMsg << utils::fourCCToStr(chunk->id()) << " chunk is too large ("
+                 << chunk->size() << " bytes) to overwrite "
+                 << utils::fourCCToStr(id) << " chunk (" << chunkHeader(id).size
+                 << " bytes)";
+        throw std::runtime_error(errorMsg.str());
+      }
+
       auto last_position = fileStream_.tellp();
       seekChunk(id);
       utils::writeChunk<ChunkType>(fileStream_, chunk, chunkSizeForHeader(id));

--- a/submodules/catch2.cmake
+++ b/submodules/catch2.cmake
@@ -1,3 +1,4 @@
 add_library(catch2 STATIC ${PROJECT_SOURCE_DIR}/submodules/catch2/catch_main.cpp)
 target_include_directories(catch2 PUBLIC ${PROJECT_SOURCE_DIR}/submodules)
 target_compile_features(catch2 PUBLIC cxx_auto_type cxx_trailing_return_types)
+target_compile_definitions(catch2 PUBLIC CATCH_CONFIG_ENABLE_BENCHMARKING)

--- a/tests/chunk_tests.cpp
+++ b/tests/chunk_tests.cpp
@@ -367,6 +367,7 @@ TEST_CASE("axml_chunk") {
   AxmlChunk chunk(str_data);
 
   REQUIRE(chunk.size() == size);
+  REQUIRE(chunk.data() == str_data);
 
   std::ostringstream stream;
   chunk.write(stream);

--- a/tests/file_tests.cpp
+++ b/tests/file_tests.cpp
@@ -16,6 +16,7 @@ TEST_CASE("read_rect_16bit") {
   REQUIRE(bw64File->sampleRate() == 44100u);
   REQUIRE(bw64File->channels() == 2u);
   REQUIRE(bw64File->numberOfFrames() == 22050u);
+  bw64File->close();
 }
 
 TEST_CASE("read_rect_24bit") {
@@ -25,6 +26,7 @@ TEST_CASE("read_rect_24bit") {
   REQUIRE(bw64File->sampleRate() == 44100u);
   REQUIRE(bw64File->channels() == 2u);
   REQUIRE(bw64File->numberOfFrames() == 22050u);
+  bw64File->close();
 }
 
 TEST_CASE("read_rect_32bit") {
@@ -34,6 +36,7 @@ TEST_CASE("read_rect_32bit") {
   REQUIRE(bw64File->sampleRate() == 44100u);
   REQUIRE(bw64File->channels() == 2u);
   REQUIRE(bw64File->numberOfFrames() == 22050u);
+  bw64File->close();
 }
 
 TEST_CASE("read_rect_24bit_rf64") {
@@ -43,6 +46,7 @@ TEST_CASE("read_rect_24bit_rf64") {
   REQUIRE(bw64File->sampleRate() == 44100u);
   REQUIRE(bw64File->channels() == 2u);
   REQUIRE(bw64File->numberOfFrames() == 22050u);
+  bw64File->close();
 }
 
 TEST_CASE("read_rect_24bit_noriff") {
@@ -68,6 +72,7 @@ TEST_CASE("read_noise_24bit_uneven_data_chunk_size") {
   REQUIRE(bw64File->chnaChunk() != nullptr);
   REQUIRE(bw64File->hasChunk(utils::fourCC("axml")) == false);
   REQUIRE(bw64File->axmlChunk() == nullptr);
+  bw64File->close();
 }
 
 TEST_CASE("read_check_chunks") {
@@ -78,6 +83,7 @@ TEST_CASE("read_check_chunks") {
   REQUIRE(bw64File->hasChunk(utils::fourCC("fmt ")) == true);
   REQUIRE(bw64File->hasChunk(utils::fourCC("chna")) == false);
   REQUIRE(bw64File->hasChunk(utils::fourCC("axml")) == false);
+  bw64File->close();
 }
 
 TEST_CASE("read_seek_tell") {
@@ -108,6 +114,8 @@ TEST_CASE("read_seek_tell") {
   REQUIRE(bw64File->tell() == 11025);
   bw64File->seek(INT32_MAX, std::ios::end);
   REQUIRE(bw64File->tell() == 22050);
+
+  bw64File->close();
 }
 
 TEST_CASE("write_16bit") {
@@ -121,6 +129,7 @@ TEST_CASE("write_16bit") {
   std::vector<float> data(frames * bw64File->channels(), 0.0);
   bw64File->write(&data[0], frames);
   REQUIRE(bw64File->framesWritten() == frames);
+  bw64File->close();
 }
 
 TEST_CASE("write_24bit") {
@@ -134,6 +143,7 @@ TEST_CASE("write_24bit") {
   std::vector<float> data(frames * bw64File->channels(), 0.0);
   bw64File->write(&data[0], frames);
   REQUIRE(bw64File->framesWritten() == frames);
+  bw64File->close();
 }
 
 TEST_CASE("write_32bit") {
@@ -147,6 +157,7 @@ TEST_CASE("write_32bit") {
   std::vector<float> data(frames * bw64File->channels(), 0.0);
   bw64File->write(&data[0], frames);
   REQUIRE(bw64File->framesWritten() == frames);
+  bw64File->close();
 }
 
 void writeClipped(const std::string& filename, uint16_t bitDepth,
@@ -155,6 +166,7 @@ void writeClipped(const std::string& filename, uint16_t bitDepth,
   auto bw64File = writeFile(filename, channels, sampleRate, bitDepth);
   std::vector<float> data(frames * channels, 2.f);
   bw64File->write(&data[0], frames);
+  bw64File->close();
 }
 
 TEST_CASE("write_read_16bit_clipped") {
@@ -218,6 +230,7 @@ void writeRandom(const std::string& filename, uint16_t bitDepth,
 
   auto bw64File = writeFile(filename, channels, sampleRate, bitDepth);
   bw64File->write(&data[0], frames);
+  bw64File->close();
 }
 
 TEST_CASE("write_read_riff_header") {
@@ -271,6 +284,8 @@ TEST_CASE("write_read_big", "[.big]") {
 
     for (uint64_t frame = 0; frame < frames; frame += block.size())
       bw64File->write(&block[0], block.size());
+
+    bw64File->close();
   }
 
   {
@@ -312,6 +327,8 @@ TEST_CASE("write_read_big_axml", "[.big]") {
     for (size_t i = 0; i < block.size(); i++)
       block[i] = (i % 2 == 0) ? 0.5f : 0.0f;
     bw64File->write(&block[0], block.size());
+
+    bw64File->close();
   }
 
   {

--- a/tests/file_tests.cpp
+++ b/tests/file_tests.cpp
@@ -270,6 +270,26 @@ TEST_CASE("can_read_all_frames") {
   REQUIRE(readSampleCount == 13);
 }
 
+TEST_CASE("write_read_odd_chunks_after") {
+  int frames = 13;
+
+  {
+    std::vector<float> data(frames, 0.5);
+    auto writer = writeFile("write_read_odd_chunks_after.wav", 1, 48000, 24);
+    writer->setAxmlChunk(std::make_shared<AxmlChunk>("axml"));
+    writer->write(&data[0], frames);
+    writer->close();
+  }
+
+  {
+    auto reader = readFile("write_read_odd_chunks_after.wav");
+    REQUIRE(reader->numberOfFrames() == frames);
+    auto axml = reader->axmlChunk();
+    REQUIRE(axml);
+    REQUIRE(axml->data() == "axml");
+  }
+}
+
 TEST_CASE("write_read_big", "[.big]") {
   uint64_t frames = 0x90000000UL;
   uint64_t blockSize = 0x1000UL;

--- a/tests/file_tests.cpp
+++ b/tests/file_tests.cpp
@@ -228,7 +228,7 @@ TEST_CASE("write_read_riff_header") {
   /**
    * 'WAVE' chunk header  :      4 bytes
    * 'JUNK' chunk header  :      8 bytes
-   * 'JUNK' chunk payload :     28 bytes
+   * 'JUNK' chunk payload :     40 bytes
    * 'fmt ' chunk header  :      8 bytes
    * 'fmt ' chunk payload :     16 bytes
    * 'chna' chunk header  :      8 bytes
@@ -236,9 +236,9 @@ TEST_CASE("write_read_riff_header") {
    * (numTracks/numUIDs) 'data' chunk header  :      8 bytes 'data' chunk
    * payload : 19.200 bytes (2 channels * 2 bytes per samples * 4800 frames)
    * --------------------------------------------------------------------------
-   *                        60244 bytes
+   *                        60256 bytes
    */
-  REQUIRE(bw64File->fileSize() == 60244);
+  REQUIRE(bw64File->fileSize() == 60256);
 }
 
 TEST_CASE("write_read_96000") {

--- a/tests/file_tests.cpp
+++ b/tests/file_tests.cpp
@@ -289,6 +289,8 @@ TEST_CASE("write_read_big", "[.big]") {
       }
     }
   }
+
+  remove(filename.c_str());
 }
 
 TEST_CASE("write_read_big_axml", "[.big]") {
@@ -338,4 +340,6 @@ TEST_CASE("write_read_big_axml", "[.big]") {
       REQUIRE(axml_data[i] == pattern[i % 4]);
     }
   }
+
+  remove(filename.c_str());
 }


### PR DESCRIPTION
This required a few changes:

- enlarge the JUNK chunk
- fix ds64 check to use ds64 when any chunks are large
- add all large chunks to ds64
- check that JUNK is large enough for ds64

... and some other improvements along the way

- add `Bw64Writer::close()` to be able to catch exceptions during finalisation
- add tests for large non-data chunks
- allow moving the string into `AxmlData`, and accessing the string with `AxmlData::data()` to avoid copies while reading/writing
- add benchmark for `AxmlChunk`
- remove files after successful `[big]` tests
- add a basic nix build