### PR TITLE
Modified Bw64Reader::seek() to take an int64_t offset argument

### DIFF
--- a/include/bw64/reader.hpp
+++ b/include/bw64/reader.hpp
@@ -218,7 +218,7 @@ namespace bw64 {
     /**
      * @brief Seek a frame position in the DataChunk
      */
-    void seek(int32_t offset, std::ios_base::seekdir way = std::ios::beg) {
+    void seek(int64_t offset, std::ios_base::seekdir way = std::ios::beg) {
       auto numberOfFramesInt = utils::safeCast<int64_t>(numberOfFrames());
 
       // where to seek relative to according to way


### PR DESCRIPTION
Changes the `offset` argument to `Bw64Reader::seek()` from `int32_t` to `int64_t` to allow proper seeks anywhere within in large audio files.