### PR TITLE
Fix compile-time warnings when compiling with MSVC and /W4

### DIFF
--- a/include/bw64/chunks.hpp
+++ b/include/bw64/chunks.hpp
@@ -125,7 +125,7 @@ namespace bw64 {
       formatTag_ = formatTag;
       channelCount_ = channels;
       sampleRate_ = sampleRate;
-      bitsPerSample_ = bitDepth;
+      bitsPerSample_ = (uint16_t) bitDepth;
       extraData_ = extraData;
 
       // validation

--- a/include/bw64/parser.hpp
+++ b/include/bw64/parser.hpp
@@ -214,11 +214,11 @@ namespace bw64 {
 
     std::map<uint32_t, uint64_t> table;
     for (uint32_t i = 0; i < tableLength; ++i) {
-      uint32_t id;
-      uint64_t size;
-      utils::readValue(stream, id);
-      utils::readValue(stream, size);
-      table[id] = size;
+      uint32_t readID;
+      uint64_t readSize;
+      utils::readValue(stream, readID);
+      utils::readValue(stream, readSize);
+      table[readID] = readSize;
     }
     // skip junk data
     stream.seekg(size - minSize, std::ios::cur);

--- a/include/bw64/reader.hpp
+++ b/include/bw64/reader.hpp
@@ -218,7 +218,7 @@ namespace bw64 {
     /**
      * @brief Seek a frame position in the DataChunk
      */
-    void seek(int32_t offset, std::ios_base::seekdir way = std::ios::beg) {
+    void seek(int64_t offset, std::ios_base::seekdir way = std::ios::beg) {
       auto numberOfFramesInt = utils::safeCast<int64_t>(numberOfFrames());
 
       // where to seek relative to according to way


### PR DESCRIPTION
This pull request fixes a few MSVC compile-time warnings that appear whenever libbw's headers are parsed while compiling code with the `/W4` compile-time flag.  Examples of the warnings that it fixes are shown below.

```
libbw\include\bw64\chunks.hpp(128,24): warning C4244: '=': conversion from 'uint32_t' to 'uint16_t', possible loss of data
libbw\include\bw64\parser.hpp(217,16): warning C4457: declaration of 'id' hides function parameter
libbw\include\bw64\parser.hpp(218,16): warning C4457: declaration of 'size' hides function parameter
```